### PR TITLE
Make docker-compose command available on console

### DIFF
--- a/cmd/control/console_init.go
+++ b/cmd/control/console_init.go
@@ -169,6 +169,21 @@ func consoleInitFunc() error {
 		}
 	*/
 
+	// create placeholder for docker-compose binary
+	const ComposePlaceholder = `
+#!/bin/bash
+echo 'System service "docker-compose" is not enabled'
+echo
+echo 'You can enable it with commands:'
+echo 'sudo ros service enable docker-compose'
+echo 'sudo ros service up docker-compose'
+`
+	if _, err := os.Stat("/var/lib/rancher/engine/docker-compose"); os.IsNotExist(err) {
+		if err := ioutil.WriteFile("/var/lib/rancher/engine/docker-compose", []byte(ComposePlaceholder), 0755); err != nil {
+			log.Error(err)
+		}
+	}
+
 	for _, link := range baseSymlink {
 		syscall.Unlink(link.newname)
 		if err := os.Symlink(link.oldname, link.newname); err != nil {

--- a/cmd/control/user_docker.go
+++ b/cmd/control/user_docker.go
@@ -27,6 +27,7 @@ const (
 	sourceDirectory       = "/engine"
 	destDirectory         = "/var/lib/rancher/engine"
 	dockerCompletionFName = "completion"
+	dockerComposeFName    = "docker-compose"
 )
 
 var (
@@ -97,6 +98,10 @@ func copyBinaries(source, dest string) error {
 		}
 		if file.Name() == dockerCompletionFName {
 			if err := os.Chmod(destFile, 0644); err != nil {
+				return err
+			}
+		} else if file.Name() == dockerComposeFName {
+			if err := os.Chmod(destFile, 0755); err != nil {
 				return err
 			}
 		} else {

--- a/cmd/control/util.go
+++ b/cmd/control/util.go
@@ -54,6 +54,8 @@ func symLinkEngineBinary() []symlink {
 		{"/var/lib/rancher/engine/docker-containerd-ctr", "/usr/bin/docker-containerd-ctr"},
 		{"/var/lib/rancher/engine/docker-containerd-shim", "/usr/bin/docker-containerd-shim"},
 		{"/var/lib/rancher/engine/docker-runc", "/usr/bin/docker-runc"},
+
+		{"/var/lib/rancher/engine/docker-compose", "/usr/bin/docker-compose"},
 	}
 	return baseSymlink
 }


### PR DESCRIPTION
Closes #18 

Added needed symlinks and included instruction for users who try use command docker-compose:
```bash
rancher@burmilla:~$ docker-compose
System service "docker-compose" is not enabled

You can enable it with command:
sudo ros service enable docker-compose
sudo ros service up docker-compose
```

Actual docker-compose service is implemented on https://github.com/burmilla/os-services/pull/6