### PR TITLE
Release v1.9.0

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -60,7 +60,7 @@ ARG DISTRIB_ID=BurmillaOS
 
 ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=4.14.207-burmilla
+ARG KERNEL_VERSION=4.14.211-burmilla
 ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
 
@@ -86,7 +86,7 @@ ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=19.03.13
+ARG USER_DOCKER_VERSION=19.03.14
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -175,8 +175,8 @@ func editSyslinux(c *cli.Context) error {
 	cmd := exec.Command("system-docker", "run", "--rm", "-it",
 		"-v", "/:/host",
 		"-w", "/host",
-		"--entrypoint=vi",
-		"rancher/os-console:"+config.Version,
+		"--entrypoint=nano",
+		"burmilla/os-console:"+config.Version,
 		"boot/global.cfg")
 	cmd.Stdout, cmd.Stderr, cmd.Stdin = os.Stdout, os.Stderr, os.Stdin
 	return cmd.Run()


### PR DESCRIPTION
I think that is it time to release official version of v1.9.0 as we do no have any critical bugs open and recently released Docker [19.03.14](https://github.com/moby/moby/releases/tag/v19.03.14) version contains also security fix to [CVE-2020-15257](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15257)