### PR TITLE
Host docker-compose on /var/lib/rancher/compose/ + enable automatically on first run

### DIFF
--- a/cmd/control/console_init.go
+++ b/cmd/control/console_init.go
@@ -157,14 +157,17 @@ func consoleInitFunc() error {
 	// create placeholder for docker-compose binary
 	const ComposePlaceholder = `
 #!/bin/bash
-echo 'System service "docker-compose" is not enabled'
-echo
-echo 'You can enable it with commands:'
-echo 'sudo ros service enable docker-compose'
-echo 'sudo ros service up docker-compose'
+echo 'INFO: System service "docker-compose" is not yet enabled'
+sudo ros service enable docker-compose
+sudo ros service up docker-compose
 `
-	if _, err := os.Stat("/var/lib/rancher/engine/docker-compose"); os.IsNotExist(err) {
-		if err := ioutil.WriteFile("/var/lib/rancher/engine/docker-compose", []byte(ComposePlaceholder), 0755); err != nil {
+	if _, err := os.Stat("/var/lib/rancher/compose"); os.IsNotExist(err) {
+		if err := os.MkdirAll("/var/lib/rancher/compose", 0555); err != nil {
+			log.Error(err)
+		}
+	}
+	if _, err := os.Stat("/var/lib/rancher/compose/docker-compose"); os.IsNotExist(err) {
+		if err := ioutil.WriteFile("/var/lib/rancher/compose/docker-compose", []byte(ComposePlaceholder), 0755); err != nil {
 			log.Error(err)
 		}
 	}

--- a/cmd/control/util.go
+++ b/cmd/control/util.go
@@ -55,7 +55,7 @@ func symLinkEngineBinary() []symlink {
 		{"/var/lib/rancher/engine/docker-containerd-shim", "/usr/bin/docker-containerd-shim"},
 		{"/var/lib/rancher/engine/docker-runc", "/usr/bin/docker-runc"},
 
-		{"/var/lib/rancher/engine/docker-compose", "/usr/bin/docker-compose"},
+		{"/var/lib/rancher/compose/docker-compose", "/usr/bin/docker-compose"},
 	}
 	return baseSymlink
 }


### PR DESCRIPTION
Moved docker-compose to /var/lib/rancher/compose so user docker version change does not destroy it.
Also changed script on way that docker-compose service will be enabled automatically when user try run command `docker-compose` first time.

Needs to be merged with https://github.com/burmilla/os-services/pull/8