### PR TITLE
Optimize kernel parameters

### DIFF
--- a/cmd/control/install.go
+++ b/cmd/control/install.go
@@ -426,7 +426,7 @@ func layDownOS(image, installType, cloudConfig, device, partition, statedir, kap
 	//cloudConfig := SCRIPTS_DIR + "/conf/empty.yml" //${cloudConfig:-"${SCRIPTS_DIR}/conf/empty.yml"}
 	CONSOLE := "tty0"
 	baseName := "/mnt/new_img"
-	kernelArgs := "printk.devkmsg=on rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait panic=10" // console="+CONSOLE
+	kernelArgs := "printk.devkmsg=on rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait transparent_hugepage=never scsi_mod.use_blk_mq=1 panic=10" // console="+CONSOLE
 	if statedir != "" {
 		kernelArgs = kernelArgs + " rancher.state.directory=" + statedir
 	}

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -97,6 +97,15 @@ rancher:
     rngd: true
   sysctl:
     fs.file-max: 1000000000
+    fs.inotify.max_user_watches: 1048576
+    vm.dirty_background_ratio: 5
+    vm.dirty_ratio: 15
+    vm.dirty_expire_centisecs: 500
+    vm.dirty_writeback_centisecs: 100
+    vm.overcommit_memory: 1
+    vm.max_map_count: 262144
+    vm.min_free_kbytes: 65536
+    vm.swappiness: 0
   services:
     command-volumes:
       image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}

--- a/scripts/global.cfg
+++ b/scripts/global.cfg
@@ -1,1 +1,1 @@
-APPEND rancher.autologin=tty1 rancher.autologin=ttyS0 rancher.autologin=ttyS1 console=tty1 console=ttyS0 console=ttyS1 printk.devkmsg=on panic=10 ${APPEND}
+APPEND rancher.autologin=tty1 rancher.autologin=ttyS0 rancher.autologin=ttyS1 console=tty1 console=ttyS0 console=ttyS1 printk.devkmsg=on transparent_hugepage=never scsi_mod.use_blk_mq=1 panic=10 ${APPEND}


### PR DESCRIPTION
Reserve 64 MB memory for admin
Set vm.max_map_count=262144 which is needed by ElasticSearch
Set fs.inotify.max_user_watches=104857 which is needed by Cadvisor
Use memory settings based on Nutanix guidance

Partly solves #34

Can be tested on https://github.com/burmilla/os/releases/tag/v1.9.1-beta1