### PR TITLE
Optimize kernel parameters for Redis

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -98,6 +98,7 @@ rancher:
   sysctl:
     fs.file-max: 1000000000
     fs.inotify.max_user_watches: 1048576
+    net.core.somaxconn: 4096
     vm.dirty_background_ratio: 5
     vm.dirty_ratio: 15
     vm.dirty_expire_centisecs: 500


### PR DESCRIPTION
Running Redis containers on top of BurmillaOS 1.9.0 generated warnings like these to log:
```
# WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.,
# WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.,
# WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
```

vm.overcommit_memory and ransparent_hugepage settings was already corrected on #36 but this PR also changes somaxconn to same value which have been set as default starting on kernel 5.4 https://github.com/torvalds/linux/commit/19f92a030ca6d772ab44b22ee6a01378a8cb32d4