### PR TITLE
Optimize kernel parameters for ElasticSearch

### DIFF
--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -99,6 +99,7 @@ rancher:
     fs.file-max: 1000000000
     fs.inotify.max_user_watches: 1048576
     net.core.somaxconn: 4096
+    net.ipv4.tcp_retries2: 5
     vm.dirty_background_ratio: 5
     vm.dirty_ratio: 15
     vm.dirty_expire_centisecs: 500


### PR DESCRIPTION
I noticed that ElasticSearch guide contains one more recommended sysctl setting which we do not have yet https://www.elastic.co/guide/en/elasticsearch/reference/current/system-config-tcpretries.html