### PR TITLE
Support user Docker userns-remap

### DIFF
--- a/config/docker_config.go
+++ b/config/docker_config.go
@@ -20,6 +20,11 @@ func (d *DockerConfig) FullArgs() []string {
 	if d.TLS {
 		args = append(args, d.TLSArgs...)
 	}
+
+	if d.UserNsEnabled {
+		args = append(args, "--userns-remap")
+		args = append(args, "user-docker:user-docker")
+	}
 	return args
 }
 

--- a/config/schema.go
+++ b/config/schema.go
@@ -143,6 +143,7 @@ var schema = `{
 				"selinux_enabled": {"type": ["boolean", "null"]},
 				"storage_driver": {"type": "string"},
 				"userland_proxy": {"type": ["boolean", "null"]},
+				"userns_enabled": {"type": ["boolean", "null"]},
 				"insecure_registry": {"$ref": "#/definitions/list_of_strings"}
 			}
 		},

--- a/config/types.go
+++ b/config/types.go
@@ -197,6 +197,7 @@ type DockerConfig struct {
 	CAKey          string   `yaml:"ca_key,omitempty"`
 	Environment    []string `yaml:"environment,omitempty"`
 	StorageContext string   `yaml:"storage_context,omitempty"`
+	UserNsEnabled  bool     `yaml:"userns_enabled,omitempty"`
 	Exec           bool     `yaml:"exec,omitempty"`
 }
 

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -39,7 +39,12 @@ RUN rm /sbin/poweroff /sbin/reboot /sbin/halt && \
     rm -f /usr/share/bash-completion/completions/* && \
     chmod 555 /lib/dhcpcd/dhcpcd-run-hooks && \
     sed -i 1,10d /etc/rsyslog.conf && \
-    echo "*.*                /var/log/syslog" >> /etc/rsyslog.conf
+    echo "*.*                /var/log/syslog" >> /etc/rsyslog.conf && \
+    \
+    addgroup -g 1200 user-docker && \
+    adduser -u 1200 -G user-docker -S -H user-docker && \
+    echo 'user-docker:100000:65536' > /etc/subuid && \
+    echo 'user-docker:100000:65536' > /etc/subgid
 # dump kernel log to console (but after we've finished booting)
 #    echo "kern.*                /dev/console" >> /etc/rsyslog.conf
 

--- a/images/02-console/Dockerfile
+++ b/images/02-console/Dockerfile
@@ -26,7 +26,12 @@ RUN apt-get update \
     && cat /etc/ssh/sshd_config > /etc/ssh/sshd_config.tpl \
     && cat /etc/ssh/sshd_config.append.tpl >> /etc/ssh/sshd_config.tpl \
     && rm -f /etc/ssh/sshd_config.append.tpl /etc/ssh/sshd_config \
-    && echo > /etc/motd
+    && echo > /etc/motd \
+    \
+    && addgroup --gid 1200 user-docker \
+    && adduser --system -u 1200 --gid 1200 --disabled-login --no-create-home user-docker \
+    && echo 'user-docker:100000:65536' > /etc/subuid \
+    && echo 'user-docker:100000:65536' > /etc/subgid
 
 COPY build/iscsid.conf /etc/iscsi/
 

--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -136,6 +136,7 @@
         "selinux_enabled": {"type": ["boolean", "null"]},
         "storage_driver": {"type": "string"},
         "userland_proxy": {"type": ["boolean", "null"]},
+        "userns_enabled": {"type": ["boolean", "null"]},
         "insecure_registry": {"$ref": "#/definitions/list_of_strings"}
       }
     },


### PR DESCRIPTION
It is possible to run containers on user namespace which improves security https://docs.docker.com/engine/security/userns-remap/

This PR includes all needed pre-requirements so users can enable that feature easily by just running:
```bash
sudo ros config set rancher.docker.userns_enabled true
sudo reboot
```

Functionality can be verified by starting some container as root user:
```bash
docker run -d --rm -u root --name nginx -p 80:80 nginx
```
and then checking processes. UID is 100000 instead of root when this feature is enabled.
```bash
$ ps -Af | grep nginx
100000    1956  1936  0 17:41 ?        00:00:00 nginx: master process nginx -g daemon off;
100101    2018  1956  0 17:41 ?        00:00:00 nginx: worker process
```

Another nice way is mount root file system inside of container and try write to it. It is read-only when this feature is enabled.
```bash
docker run -it -v /:/host bash bash
$ touch /host/test
touch: /host/test: Permission denied
```

This will need changed also to https://github.com/burmilla/burmilla.github.io/blob/master/content/docs/configuration/docker/_index.md
