### PR TITLE
Use HOST_ARCH for downloading golang compiler.

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -157,7 +157,7 @@ RUN echo "... Downloading  ${!KERNEL_URL}"; \
 RUN curl -pfL ${SELINUX_POLICY_URL} > ${DOWNLOADS}/$(basename ${SELINUX_POLICY_URL})
 
 # Install Go
-RUN curl -L https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GOARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN curl -L https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${HOST_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/burmilla/trash
 
 # Install golint


### PR DESCRIPTION
GOARCH is target `ARCH`, and should be used for only compiling target binaries, not for downloading the golang compiler. The compiler needs to use `HOST_ARCH` instead.