### PR TITLE
Create v2.0.0-beta4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -60,10 +60,10 @@ ARG DISTRIB_ID=BurmillaOS
 
 ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=5.4.0-54.60-rancher1
-ARG KERNEL_URL_amd64=https://github.com/rancher/k3os-kernel/releases/download/${KERNEL_VERSION}/kernel-generic_amd64.tar.xz
-ARG KERNEL_URL_arm64=https://github.com/rancher/k3os-kernel/releases/download/${KERNEL_VERSION}/kernel-generic_arm64.tar.xz
-ARG KERNEL_URL_mips64el=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-mips64el.tar.xz
+ARG KERNEL_VERSION=5.10.28-burmilla
+ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
+ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
+ARG KERNEL_URL_mips64el=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-mips64el.tar.gz
 
 ARG BUILD_DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3
 ARG BUILD_DOCKER_URL_arm64=https://github.com/burmilla/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64
@@ -91,7 +91,7 @@ ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/release
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_mips64el=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-mips64el-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=20.10.3
+ARG USER_DOCKER_VERSION=20.10.5
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
+++ b/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
@@ -10,8 +10,8 @@ RUN mkdir -p /source/assets
 
 COPY rootfs_arm64.tar.gz /source/assets/rootfs_arm64.tar.gz
 
-ENV KERNEL_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.1-burmilla/5.10.1-burmilla-v8.tar.gz
-ENV BOOTLOADER_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.1-burmilla/rpi-bootloader.tar.gz
+ENV KERNEL_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.27-burmilla/5.10.27-burmilla-v8.tar.gz
+ENV BOOTLOADER_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.27-burmilla/rpi-bootloader.tar.gz
 
 RUN curl -fL ${KERNEL_URL} > /source/assets/kernel.tar.gz
 RUN curl -fL ${BOOTLOADER_URL} > /source/assets/rpi-bootloader.tar.gz


### PR DESCRIPTION
Looks that UEFI support #8 will take a while to get ready so let's create new beta release with latest 5.10.x kernel and Raspberry Pi 4 compability.

Changes:
- Kernel 5.10.28 (5.10.27 for Raspberry Pi)
- Docker 20.10.5