### PR TITLE
Change console back to iptables-legacy

### DIFF
--- a/images/02-console/Dockerfile
+++ b/images/02-console/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update \
                            sudo less curl ca-certificates psmisc htop kmod iproute2 \
                            net-tools bash-completion wget \
                            nano open-iscsi iputils-ping \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /etc/ssh/*key* \
     && echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen \


### PR DESCRIPTION
As part of v1.9.0 creation we switched default console to Debian and updated it to latest stable https://github.com/burmilla/os/commit/4e5d2482980b614480d99ff3c4de33c4562502c5#diff-4c2844aaed1ab6d369716dd1342690f3f415fac499e9ec8ade02d1c9a1dfb2b7L1-L3

Unfortunately that one did came with unexpected change that now on console command `iptables` points to `iptables-nft` when rest of the OS is still using `iptables-legacy`. This PR will change it back.

Closes #77