### PR TITLE
Use noop scheduler for maximum performance

### DIFF
--- a/cmd/control/install.go
+++ b/cmd/control/install.go
@@ -426,7 +426,7 @@ func layDownOS(image, installType, cloudConfig, device, partition, statedir, kap
 	//cloudConfig := SCRIPTS_DIR + "/conf/empty.yml" //${cloudConfig:-"${SCRIPTS_DIR}/conf/empty.yml"}
 	CONSOLE := "tty0"
 	baseName := "/mnt/new_img"
-	kernelArgs := "printk.devkmsg=on rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait transparent_hugepage=never scsi_mod.use_blk_mq=1 panic=10" // console="+CONSOLE
+	kernelArgs := "printk.devkmsg=on rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait transparent_hugepage=never scsi_mod.use_blk_mq=1 elevator=noop panic=10" // console="+CONSOLE
 	if statedir != "" {
 		kernelArgs = kernelArgs + " rancher.state.directory=" + statedir
 	}

--- a/images/02-console/iscsid.conf
+++ b/images/02-console/iscsid.conf
@@ -111,7 +111,7 @@ node.conn[0].timeo.noop_out_interval = 5
 # the connection, edit this line. Failing the connection will
 # cause IO to be failed back to the SCSI layer. If using dm-multipath
 # this will cause the IO to be failed to the multipath layer.
-node.conn[0].timeo.noop_out_timeout = 5
+node.conn[0].timeo.noop_out_timeout = 10
 
 # To specify the time to wait for abort response before
 # failing the operation and trying a logical unit reset edit the line.

--- a/scripts/global.cfg
+++ b/scripts/global.cfg
@@ -1,1 +1,1 @@
-APPEND rancher.autologin=tty1 rancher.autologin=ttyS0 rancher.autologin=ttyS1 console=tty1 console=ttyS0 console=ttyS1 printk.devkmsg=on transparent_hugepage=never scsi_mod.use_blk_mq=1 panic=10 ${APPEND}
+APPEND rancher.autologin=tty1 rancher.autologin=ttyS0 rancher.autologin=ttyS1 console=tty1 console=ttyS0 console=ttyS1 printk.devkmsg=on transparent_hugepage=never scsi_mod.use_blk_mq=1 elevator=noop panic=10 ${APPEND}


### PR DESCRIPTION
Two more settings which I noticed when I did read Nutanix guidance more carefully:
- Use noop scheduler for maximum performance: https://www.techrepublic.com/article/how-to-change-the-linux-io-scheduler-to-fit-your-needs/ and https://storagetuning.wordpress.com/2011/05/25/linux-elevator-settings-impact-on-ssds/
- Small increase to noop_out_timeout 