### PR TITLE
Revendor customized from burmilla repos

### DIFF
--- a/trash.conf
+++ b/trash.conf
@@ -1,12 +1,12 @@
 github.com/Microsoft/go-winio v0.1.0
 github.com/Sirupsen/logrus v0.11.5
-github.com/cloudfoundry-incubator/candiedyaml 457a86017e98f33631ffe83db8e66be960dfc517 https://github.com/rancher/candiedyaml
-github.com/codegangsta/cli d2b9ba9c38eb353ba3c6df3f57072348e19cc5c7 https://github.com/rancher/cli-1
+github.com/cloudfoundry-incubator/candiedyaml 457a86017e98f33631ffe83db8e66be960dfc517 https://github.com/burmilla/candiedyaml
+github.com/codegangsta/cli d2b9ba9c38eb353ba3c6df3f57072348e19cc5c7 https://github.com/burmilla/cli-1
 github.com/coreos/yaml 6b16a5714269b2f70720a45406b1babd947a17ef
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
-github.com/docker/containerd b7a26a1c481d5ba88a2df757954a54439142ceb1 https://github.com/ibuildthecloud/containerd.git
+github.com/docker/containerd 0c177afbc8e949d150efec0e61bd37182c69c634 https://github.com/burmilla/containerd.git
 github.com/docker/distribution 467fc068d88aa6610691b7f1a677271a3fac4aac 
-github.com/docker/docker b40c87254f587af7cad8e8128f061a2a7f367343 https://github.com/rancher/docker.git
+github.com/docker/docker b40c87254f587af7cad8e8128f061a2a7f367343 https://github.com/burmilla/docker.git
 github.com/docker/engine-api v0.3.3
 github.com/docker/go-connections v0.2.0
 github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
@@ -18,7 +18,7 @@ github.com/gorilla/context 14f550f51a
 github.com/gorilla/mux e444e69cbd 
 github.com/j-keck/arping 4f4d2c8983a18e2c9c63a3f339bc9a998c4557bc
 github.com/tredoe/term e551c64f56c0ac0469b4db1b70918e05bfd3ab20
-github.com/opencontainers/runc edc34c4a8c1e261b5ce926ff557ecde1aff19ce3 https://github.com/ibuildthecloud/runc.git
+github.com/opencontainers/runc edc34c4a8c1e261b5ce926ff557ecde1aff19ce3 https://github.com/burmilla/runc.git
 github.com/packethost/packngo v0.1.0
 github.com/pkg/errors d62207b3dc916c342cd6a7180fa861d898cf42ee
 github.com/pmezard/go-difflib d8ed2627bdf02c080bf22230dbb337003b7aba2d
@@ -29,7 +29,7 @@ github.com/sigma/vmw-ovflib master
 github.com/sigma/bdoor master
 github.com/stretchr/testify a1f97990ddc16022ec7610326dd9bce31332c116
 github.com/vbatts/tar-split v0.9.11
-github.com/vishvananda/netlink b76f71f1d33745ac0833fff4277481599a8ee73f https://github.com/niusmallnan/netlink
+github.com/vishvananda/netlink b76f71f1d33745ac0833fff4277481599a8ee73f https://github.com/burmilla/netlink
 github.com/vishvananda/netns 54f0e4339ce73702a0607f49922aaa1e749b418d
 github.com/xeipuuv/gojsonpointer 6fe8760cad3569743d51ddbb243b26f8456742dc
 github.com/xeipuuv/gojsonreference e02fc20de94c78484cd5ffb007f8af96be030a45


### PR DESCRIPTION
I noticed that trash config was still pointing to Rancher repos and we almost lost track of our containerd customizations.

I collected content from those customizations to https://github.com/burmilla/containerd/pull/1 and this one revendor sources from our branches. Only trash.conf changes as actual sources under vendor/... are still same.