### PR TITLE
Added libisl-dev dependency to dapper dockerfile.

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,6 +8,7 @@ RUN echo "Acquire::http { Proxy \"$APTPROXY\"; };" >> /etc/apt/apt.conf.d/01prox
     && cat /etc/apt/apt.conf.d/01proxy \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+        libisl-dev \
         build-essential \
         ca-certificates \
         cpio \


### PR DESCRIPTION
The `libisl-dev` package doesn't get installed before packages depending on it, which I assume are in `build-essential`, causing an error.