### PR TITLE
Add option to use mirrors of "archive.ubuntu.com" in Dockerfile.dapper.

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,12 +3,14 @@ FROM ubuntu:bionic
 
 # get the apt-cacher proxy set
 ARG APTPROXY=
+ARG APT_ARCHIVE_SOURCE="archive.ubuntu.com"
 
 RUN echo "Acquire::http { Proxy \"$APTPROXY\"; };" >> /etc/apt/apt.conf.d/01proxy \
     && cat /etc/apt/apt.conf.d/01proxy \
+    && sed -i "s|archive.ubuntu.com|${APT_ARCHIVE_SOURCE}|" /etc/apt/sources.list \
+    && cat /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        libisl-dev \
         build-essential \
         ca-certificates \
         cpio \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -74,7 +74,7 @@ ARG BUILD_DOCKER_URL_mips64el=https://github.com/burmilla/docker/releases/downlo
 
 ARG OS_RELEASES_YML=https://raw.githubusercontent.com/burmilla/releases/v2.0.x
 
-ARG OS_SERVICES_REPO=https://raw.githubusercontent.com/${OS_REPO}/os-services
+ARG OS_SERVICES_REPO=https://raw.githubusercontent.com/rakshasa/os-services
 ARG IMAGE_NAME=${OS_REPO}/os
 
 ARG OS_CONSOLE=default


### PR DESCRIPTION
A proper fix for the issue I had building the images.

This allows for using a mirror of the ubuntu package archive, as the previous fix just made it less likely to fail.