### PR TITLE
Prepare v1.9.2-rc3

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -60,7 +60,7 @@ ARG DISTRIB_ID=BurmillaOS
 
 ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=4.14.229-burmilla
+ARG KERNEL_VERSION=4.14.235-burmilla
 ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
 
@@ -86,7 +86,7 @@ ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=19.03.15
+ARG USER_DOCKER_VERSION=20.10.7
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -76,11 +76,11 @@ ARG OS_CONSOLE=default
 ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
-ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2018.02.11-1/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2018.02.11-1/os-base_arm64.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2021.02.2-kernel-4.14.x/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2021.02.2-kernel-4.14.x/os-base_arm64.tar.xz
 
-ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2018.02.11-1/os-initrd-base-amd64.tar.gz
-ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2018.02.11-1/os-initrd-base-arm64.tar.gz
+ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2021.02.2-kernel-4.14.x/os-initrd-base-amd64.tar.gz
+ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2021.02.2-kernel-4.14.x/os-initrd-base-arm64.tar.gz
 
 ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -25,7 +25,6 @@ RUN rm /sbin/poweroff /sbin/reboot /sbin/halt && \
     passwd -l root && \
     addgroup -g 1100 rancher && \
     addgroup -g 1101 docker && \
-    addgroup -g 1103 sudo && \
     adduser -u 1100 -G rancher -D -h /home/rancher -s /bin/bash rancher && \
     adduser -u 1101 -G docker -D -h /home/docker -s /bin/bash docker && \
     adduser rancher docker && \


### PR DESCRIPTION
I think that we should create one more RC version before releasing 1.9.2 because of size of changes.

This PR contains following changes:
* Switch default Docker version from 19.03.15 to 20.10.7 (Closes #71)
* Update buildroot from 2018.02.11 to 2021.02.2 which hopefully fixes to #52 and #65 (needs more testing)
