### PR TITLE
Added nvi to base console docker image.

### DIFF
--- a/images/02-console/Dockerfile
+++ b/images/02-console/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends iptables openssh-server rsync locales \
                            sudo less curl ca-certificates psmisc htop kmod iproute2 \
                            net-tools bash-completion wget \
-                           nano open-iscsi iputils-ping \
+                           nano open-iscsi iputils-ping nvi \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Added nvi to the console base image, resulting in around 500k additional disk space used.  This should hopefully not impact existing deployments too greatly.