### PR TITLE
Lock console to Debian buster

### DIFF
--- a/images/02-console/Dockerfile
+++ b/images/02-console/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:buster-slim
 
 COPY build/sshd_config.append.tpl /etc/ssh/
 COPY build/lsb-release /etc/


### PR DESCRIPTION
Found issue on our environment that apt-get did install version of open-iscsi which does not works correctly as it comes from Debian 11 (bullseye) repo so it is better to switch back to Debian 10 (buster).