### PR TITLE
Release v1.9.4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -60,7 +60,7 @@ ARG DISTRIB_ID=BurmillaOS
 
 ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=4.14.269-burmilla
+ARG KERNEL_VERSION=4.14.270-burmilla
 ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
 
@@ -76,17 +76,17 @@ ARG OS_CONSOLE=default
 ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
-ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2021.11.2-kernel-4.14.x/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2021.11.2-kernel-4.14.x/os-base_arm64.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x/os-base_arm64.tar.xz
 
-ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2021.11.2-kernel-4.14.x/os-initrd-base-amd64.tar.gz
-ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2021.11.2-kernel-4.14.x/os-initrd-base-arm64.tar.gz
+ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02-kernel-4.14.x/os-initrd-base-amd64.tar.gz
+ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02-kernel-4.14.x/os-initrd-base-arm64.tar.gz
 
 ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=20.10.12
+ARG USER_DOCKER_VERSION=20.10.13
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false


### PR DESCRIPTION
As mentioned on https://github.com/burmilla/os/issues/129#issuecomment-1064407366 new LTS version of Buildroot and new Docker engine got released on yesterday so I think that it is time to release v1.9.4 

Draft release is already available but will do some more testing before marking it public.