### PR TITLE
Release v1.9.5-rc1

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -76,8 +76,8 @@ ARG OS_CONSOLE=default
 ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
-ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x/os-base_arm64.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x-2/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x-2/os-base_arm64.tar.xz
 
 ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02-kernel-4.14.x/os-initrd-base-amd64.tar.gz
 ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02-kernel-4.14.x/os-initrd-base-arm64.tar.gz


### PR DESCRIPTION
Using patched version of os-base with https://github.com/burmilla/os-base/commit/5dd93a3a9c6ee38b3f8f1d760ecebbf5de02f368 to fix #132

I will release it as RC version now because obviously we need to do better testing before we are sure that other new issues was not introduced by updated buildroot.