### PR TITLE
2.0.0-beta update

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -94,7 +94,7 @@ ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/release
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_mips64el=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-mips64el-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=20.10.13
+ARG USER_DOCKER_VERSION=22.06.0beta0
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -66,11 +66,9 @@ ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v
 ARG KERNEL_VERSION=5.10.129-burmilla
 ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
-ARG KERNEL_URL_mips64el=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-mips64el.tar.gz
 
 ARG BUILD_DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3
 ARG BUILD_DOCKER_URL_arm64=https://github.com/burmilla/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64
-ARG BUILD_DOCKER_URL_mips64el=https://github.com/burmilla/docker/releases/download/v1.10.3-ros1/docker-1.10.3_mips64el
 
 ARG OS_RELEASES_YML=https://raw.githubusercontent.com/burmilla/releases/v2.0.x
 
@@ -83,16 +81,13 @@ ARG OS_FIRMWARE=true
 
 ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.3-1/os-base_amd64.tar.xz
 ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2020.02.8-1/os-base_arm64.tar.xz
-ARG OS_BASE_URL_mips64el=https://github.com/burmilla/os-base/releases/download/v2020.02.8-1/os-base_mips64el.tar.xz
 
 ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.3-1/os-initrd-base-amd64.tar.gz
 ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2020.02.8-1/os-initrd-base-arm64.tar.gz
-ARG OS_INITRD_BASE_URL_mips64el=https://github.com/burmilla/os-initrd-base/releases/download/v2020.02.8-1/os-initrd-base-mips64el.tar.gz
 
 ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
-ARG SYSTEM_DOCKER_URL_mips64el=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-mips64el-${SYSTEM_DOCKER_VERSION}.tgz
 
 ARG USER_DOCKER_VERSION=22.06.0beta0
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -81,11 +81,11 @@ ARG OS_CONSOLE=default
 ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
-ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2020.02.8-1/os-base_amd64.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.3-1/os-base_amd64.tar.xz
 ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2020.02.8-1/os-base_arm64.tar.xz
 ARG OS_BASE_URL_mips64el=https://github.com/burmilla/os-base/releases/download/v2020.02.8-1/os-base_mips64el.tar.xz
 
-ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2020.02.8-1/os-initrd-base-amd64.tar.gz
+ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.3-1/os-initrd-base-amd64.tar.gz
 ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2020.02.8-1/os-initrd-base-arm64.tar.gz
 ARG OS_INITRD_BASE_URL_mips64el=https://github.com/burmilla/os-initrd-base/releases/download/v2020.02.8-1/os-initrd-base-mips64el.tar.gz
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -80,10 +80,10 @@ ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
 ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.3-1/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2020.02.8-1/os-base_arm64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02.3-1/os-base_arm64.tar.xz
 
 ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.3-1/os-initrd-base-amd64.tar.gz
-ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2020.02.8-1/os-initrd-base-arm64.tar.gz
+ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.3-1/os-initrd-base-arm64.tar.gz
 
 ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -63,7 +63,7 @@ ARG DISTRIB_ID=BurmillaOS
 
 ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=5.10.28-burmilla
+ARG KERNEL_VERSION=5.10.129-burmilla
 ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
 ARG KERNEL_URL_mips64el=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-mips64el.tar.gz
@@ -94,7 +94,7 @@ ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/release
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_mips64el=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-mips64el-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=20.10.5
+ARG USER_DOCKER_VERSION=20.10.13
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/images/01-base/Dockerfile
+++ b/images/01-base/Dockerfile
@@ -34,6 +34,7 @@ RUN rm /sbin/poweroff /sbin/reboot /sbin/halt && \
     ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules && \
     sed -i s/"partx --update \"\$part\" \"\$dev\""/"partx --update --nr \"\$part\" \"\$dev\""/g /usr/bin/growpart && \
     sed -i -e 's/duid/clientid/g' /etc/dhcpcd.conf && \
+    echo -e '\n# Ignore Docker container interfaces\ndenyinterfaces veth*\n' >> /etc/dhcpcd.conf && \
     rm -f /etc/wpa_supplicant.conf && \
     ln -s /usr/share/dhcpcd/hooks/10-wpa_supplicant /lib/dhcpcd/dhcpcd-hooks/ && \
     rm -f /usr/share/bash-completion/completions/* && \

--- a/images/01-base/etc/dhcpcd.conf.tpl
+++ b/images/01-base/etc/dhcpcd.conf.tpl
@@ -39,6 +39,9 @@ require dhcp_server_identifier
 # OR generate Stable Private IPv6 Addresses based from the DUID
 slaac private
 
+# Ignore Docker container interfaces
+denyinterfaces veth*
+
 {{- range $key, $value := .}}
 interface {{$key}}
 static ip_address={{$value.Address}}

--- a/images/02-console/Dockerfile
+++ b/images/02-console/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 COPY build/sshd_config.append.tpl /etc/ssh/
 COPY build/lsb-release /etc/

--- a/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
+++ b/scripts/images/raspberry-pi-hypriot64/Dockerfile.dapper
@@ -10,8 +10,8 @@ RUN mkdir -p /source/assets
 
 COPY rootfs_arm64.tar.gz /source/assets/rootfs_arm64.tar.gz
 
-ENV KERNEL_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.27-burmilla/5.10.27-burmilla-v8.tar.gz
-ENV BOOTLOADER_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.27-burmilla/rpi-bootloader.tar.gz
+ENV KERNEL_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.110-burmilla/5.10.110-burmilla-v8.tar.gz
+ENV BOOTLOADER_URL=https://github.com/burmilla/os-rpi-kernel/releases/download/v5.10.110-burmilla/rpi-bootloader.tar.gz
 
 RUN curl -fL ${KERNEL_URL} > /source/assets/kernel.tar.gz
 RUN curl -fL ${BOOTLOADER_URL} > /source/assets/rpi-bootloader.tar.gz

--- a/scripts/release-amd64
+++ b/scripts/release-amd64
@@ -14,6 +14,8 @@ if [ "$OS_FIRMWARE" = "false" ]; then
     exit 0
 else
     echo "github-release release --user burmilla --repo os --tag ${VERSION} --pre-release --draft" > dist/publish.sh
+    echo "echo Waiting 30 seconds after release creation to make sure that GitHub is ready for uploads" >> dist/publish.sh
+    echo "sleep 30s" >> dist/publish.sh
 
     echo "github-release upload --user burmilla --repo os --tag ${VERSION} --file ./dist/artifacts/burmillaos.iso --name burmillaos-${VERSION}.iso" >> dist/publish.sh
 


### PR DESCRIPTION
Cherry-picked relevant commits from [build-1.9.5-rc2](https://github.com/burmilla/os/tree/build-1.9.5-rc2) to bring master in line with the v4.14.x branch changes. Also Updated:
- Kernel 5.10.129
- Docker 20.10.13
- Buildroot 2022.02.3

This pre-emptively fixes #132 in the 2.0.0-beta release.

This PR also adds wireguard to the kernel.