### PR TITLE
Publish v1.9.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__
 .trash-conf
 /Dockerfile.dapper*
 !/Dockerfile.dapper
+.vscode/*

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -60,7 +60,7 @@ ARG DISTRIB_ID=BurmillaOS
 
 ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=4.14.270-burmilla
+ARG KERNEL_VERSION=4.14.292-burmilla
 ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
 
@@ -76,17 +76,17 @@ ARG OS_CONSOLE=default
 ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
-ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x-2/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02-kernel-4.14.x-2/os-base_arm64.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.5-kernel-4.14.x/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02.5-kernel-4.14.x/os-base_arm64.tar.xz
 
-ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02-kernel-4.14.x/os-initrd-base-amd64.tar.gz
-ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02-kernel-4.14.x/os-initrd-base-arm64.tar.gz
+ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.5-kernel-4.14.x/os-initrd-base-amd64.tar.gz
+ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.5-kernel-4.14.x/os-initrd-base-arm64.tar.gz
 
 ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=20.10.13
+ARG USER_DOCKER_VERSION=20.10.18
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -291,6 +291,8 @@ rancher:
       - command-volumes
       volumes:
       - /usr/bin/iptables:/sbin/iptables:ro
+      restart: always
+      mem_limit: 20971520
     ntp:
       image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}
       command: /bin/start_ntp.sh


### PR DESCRIPTION
I think that it is time to release v1.9.5.

It finally fixes #129 by restarting network container if it memory usage exceed 20MB.
Other changes:
* Kernel 4.14.292
* [Docker 20.10.18](https://github.com/moby/moby/releases/tag/v20.10.18) by default.
* Buildroot 2022.02.5 