### PR TITLE
Publish v1.9.6

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -60,7 +60,7 @@ ARG DISTRIB_ID=BurmillaOS
 
 ARG SELINUX_POLICY_URL=https://github.com/burmilla/refpolicy/releases/download/v0.0.3/policy.29
 
-ARG KERNEL_VERSION=4.14.292-burmilla
+ARG KERNEL_VERSION=4.14.300-burmilla
 ARG KERNEL_URL_amd64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
 ARG KERNEL_URL_arm64=https://github.com/burmilla/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-arm64.tar.gz
 
@@ -76,17 +76,17 @@ ARG OS_CONSOLE=default
 ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
-ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.5-kernel-4.14.x/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02.5-kernel-4.14.x/os-base_arm64.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.7-kernel-4.14.x/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02.7-kernel-4.14.x/os-base_arm64.tar.xz
 
-ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.5-kernel-4.14.x/os-initrd-base-amd64.tar.gz
-ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.5-kernel-4.14.x/os-initrd-base-arm64.tar.gz
+ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.7-kernel-4.14.x/os-initrd-base-amd64.tar.gz
+ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.7-kernel-4.14.x/os-initrd-base-arm64.tar.gz
 
 ARG SYSTEM_DOCKER_VERSION=17.06-ros6
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=20.10.18
+ARG USER_DOCKER_VERSION=20.10.22
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ rpi64: .dapper
 vmware: .dapper
 	mkdir -p dist
 	OS_FIRMWARE="false" \
-	APPEND_SYSTEM_IMAGES="burmilla/os-openvmtools:11.2.0-5" \
+	APPEND_SYSTEM_IMAGES="burmilla/os-openvmtools:12.1.5-1" \
 	./.dapper release-vmware
 
 hyperv: .dapper


### PR DESCRIPTION
Preparation for security related version:
* Kernel 4.14.300
* [Docker 20.10.22](https://github.com/moby/moby/releases/tag/v20.10.22)
* Buildroot 2022.02.7
* VMware tools 12.1.5

~Marked as draft because waiting Docker version to be released.~

Closes #143