### PR TITLE
Publish v1.9.7-rc1

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -76,17 +76,17 @@ ARG OS_CONSOLE=default
 ARG OS_AUTOFORMAT=false
 ARG OS_FIRMWARE=true
 
-ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.7-kernel-4.14.x/os-base_amd64.tar.xz
-ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02.7-kernel-4.14.x/os-base_arm64.tar.xz
+ARG OS_BASE_URL_amd64=https://github.com/burmilla/os-base/releases/download/v2022.02.7-kernel-4.14.x-2/os-base_amd64.tar.xz
+ARG OS_BASE_URL_arm64=https://github.com/burmilla/os-base/releases/download/v2022.02.7-kernel-4.14.x-2/os-base_arm64.tar.xz
 
 ARG OS_INITRD_BASE_URL_amd64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.7-kernel-4.14.x/os-initrd-base-amd64.tar.gz
 ARG OS_INITRD_BASE_URL_arm64=https://github.com/burmilla/os-initrd-base/releases/download/v2022.02.7-kernel-4.14.x/os-initrd-base-arm64.tar.gz
 
-ARG SYSTEM_DOCKER_VERSION=17.06-ros6
+ARG SYSTEM_DOCKER_VERSION=17.06.107
 ARG SYSTEM_DOCKER_URL_amd64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-amd64-${SYSTEM_DOCKER_VERSION}.tgz
 ARG SYSTEM_DOCKER_URL_arm64=https://github.com/burmilla/os-system-docker/releases/download/${SYSTEM_DOCKER_VERSION}/docker-arm64-${SYSTEM_DOCKER_VERSION}.tgz
 
-ARG USER_DOCKER_VERSION=20.10.22
+ARG USER_DOCKER_VERSION=20.10.23
 ARG USER_DOCKER_ENGINE_VERSION=docker-${USER_DOCKER_VERSION}
 
 ARG AZURE_SERVICE=false

--- a/os-config.tpl.yml
+++ b/os-config.tpl.yml
@@ -292,7 +292,7 @@ rancher:
       volumes:
       - /usr/bin/iptables:/sbin/iptables:ro
       restart: always
-      mem_limit: 20971520
+      mem_limit: 104857600
     ntp:
       image: {{.OS_REPO}}/os-base:{{.VERSION}}{{.SUFFIX}}
       command: /bin/start_ntp.sh

--- a/scripts/global.cfg
+++ b/scripts/global.cfg
@@ -1,1 +1,1 @@
-APPEND rancher.autologin=tty1 rancher.autologin=ttyS0 rancher.autologin=ttyS1 console=tty1 console=ttyS0 console=ttyS1 printk.devkmsg=on transparent_hugepage=never scsi_mod.use_blk_mq=1 panic=10 ${APPEND}
+APPEND rancher.autologin=tty1 rancher.autologin=ttyS0 rancher.autologin=ttyS1 console=tty1 console=ttyS0 console=ttyS1 printk.devkmsg=on transparent_hugepage=never scsi_mod.use_blk_mq=1 ${APPEND}

--- a/scripts/isolinux_label.cfg
+++ b/scripts/isolinux_label.cfg
@@ -12,14 +12,14 @@ LABEL rancheros-${LABEL}-autologin
     MENU LABEL Autologin on tty1 and ttyS0
     MENU INDENT 2
     COM32 cmd.c32
-    APPEND rancheros-${LABEL} rancher.autologin=tty1 rancher.autologin=ttyS0
+    APPEND rancheros-${LABEL} panic=10 rancher.autologin=tty1 rancher.autologin=ttyS0
 
 LABEL rancheros-${LABEL}-debug
     SAY rancheros-${LABEL}-debug: debug BurmillaOS ${VERSION} ${KERNEL_VERSION}
     MENU LABEL Debug logging
     MENU INDENT 2
     COM32 cmd.c32
-    APPEND rancheros-${LABEL} rancher.debug=true
+    APPEND rancheros-${LABEL} rancher.debug=true vga=ask
 
 LABEL rancheros-${LABEL}-debug-autologin
     SAY rancheros-${LABEL}-debug-autolgin: debug and autologin BurmillaOS ${VERSION} ${KERNEL_VERSION}


### PR DESCRIPTION
* [Docker 20.10.23](https://github.com/moby/moby/releases/tag/v20.10.23)
* [System-Docker 17.06.107](https://github.com/burmilla/os-system-docker/releases/tag/17.06.107)
* Cherry-picked patch to NetworkConfiguration/dhcpcd#157
* Increased network container memory limit to 100 MB
* Improve debug mode by disabling auto reboot and asking resolution

Hopefully solved #151 and #129