### PR TITLE
Replace cgroup v1 mounts with cgroup2 on /sys/fs/cgroup in switched root

### DIFF
--- a/pkg/dfs/scratch.go
+++ b/pkg/dfs/scratch.go
@@ -29,6 +29,8 @@ const (
 	// stay at /sys/fs/cgroup/<controller> for System Docker, the unified
 	// hierarchy is available next to them for software that supports it.
 	cgroupV2Path = "/sys/fs/cgroup/unified"
+	// CGROUP2_SUPER_MAGIC from statfs(2)
+	cgroup2SuperMagic = 0x63677270
 )
 
 var (
@@ -88,18 +90,37 @@ func createDirs(dirs ...string) error {
 	return nil
 }
 
-// cgroupsLegacyV1 reports whether the kernel command line requests the
+// CgroupsLegacyV1 reports whether the kernel command line requests the
 // pre-3.x behavior of mounting every controller on cgroup v1
-// (rancher.cgroups.legacy). The v2 hierarchy is then still mounted but has
-// no controllers, and the console keeps its v1 layout.
-func cgroupsLegacyV1() bool {
+// (rancher.cgroups.legacy). The hybrid v1 layout is then kept in the
+// switched root instead of being replaced by a single cgroup2 mount
+// (see pkg/init/switchroot).
+func CgroupsLegacyV1() bool {
 	if v, ok := cmdline.GetCmdline("rancher.cgroups.legacy").(bool); ok {
 		return v
 	}
 	return false
 }
 
+// cgroup2Mounted reports whether /sys/fs/cgroup itself is a cgroup2 mount,
+// the layout pkg/init/switchroot sets up in the switched root.
+func cgroup2Mounted() bool {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs("/sys/fs/cgroup", &fs); err != nil {
+		return false
+	}
+	return fs.Type == cgroup2SuperMagic
+}
+
 func mountCgroups(hierarchyConfig map[string]string) error {
+	if cgroup2Mounted() {
+		// switchroot has replaced the hybrid v1 layout with a single
+		// cgroup2 mount; recreating the v1 hierarchies here would make
+		// them visible in the switched root again.
+		log.Debug("cgroup2 is the primary cgroup filesystem, not mounting cgroup v1 hierarchies")
+		return nil
+	}
+
 	f, err := os.Open("/proc/cgroups")
 	if err != nil {
 		return err

--- a/pkg/init/switchroot/switchroot.go
+++ b/pkg/init/switchroot/switchroot.go
@@ -112,6 +112,24 @@ func copyMoveRoot(rootfs string, rmUsr bool) error {
 	return nil
 }
 
+// switchToCgroupV2 detaches the cgroup mounts the switched root inherited
+// from the initrd (the tmpfs on /sys/fs/cgroup with the v1 controller
+// hierarchies and the unified mount below it) and mounts the cgroup v2
+// unified hierarchy as the only cgroup filesystem on /sys/fs/cgroup, so
+// user mode sees cgroup v2 only while PID 1 keeps its cgroup v1 usage to
+// itself. Booting with rancher.cgroups.legacy skips this and keeps the
+// v1 layout visible in the switched root.
+func switchToCgroupV2() error {
+	log.Debug("Detaching cgroup v1 mounts from /sys/fs/cgroup")
+	if err := syscall.Unmount("/sys/fs/cgroup", syscall.MNT_DETACH); err != nil {
+		return err
+	}
+
+	log.Debug("Mounting cgroup2 to /sys/fs/cgroup")
+	return syscall.Mount("cgroup2", "/sys/fs/cgroup", "cgroup2",
+		syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "nsdelegate")
+}
+
 func switchRoot(rootfs, subdir string, rmUsr bool) error {
 	if err := syscall.Unmount(config.OemDir, 0); err != nil {
 		log.Debugf("Not umounting OEM: %v", err)
@@ -165,6 +183,12 @@ func switchRoot(rootfs, subdir string, rmUsr bool) error {
 	log.Debug("chdir /")
 	if err := syscall.Chdir("/"); err != nil {
 		return err
+	}
+
+	if dfs.CgroupsLegacyV1() {
+		log.Debug("Keeping cgroup v1 layout in the switched root")
+	} else if err := switchToCgroupV2(); err != nil {
+		log.Errorf("Failed to replace cgroup v1 mounts with cgroup2: %v", err)
 	}
 
 	log.Debugf("Successfully moved to new root at %s", path.Join(rootfs, subdir))


### PR DESCRIPTION
After chrooting into the switched root, detach the cgroup layout inherited from the initrd (the tmpfs on /sys/fs/cgroup with the v1 controller hierarchies and the unified mount below it) and mount the cgroup v2 unified hierarchy as the only cgroup filesystem on /sys/fs/cgroup, so user mode sees cgroup v2 only while PID 1 keeps cgroup v1 to itself. Export dfs.CgroupsLegacyV1 and check it first: booting with rancher.cgroups.legacy skips the replacement and keeps the hybrid v1 layout visible.

mountCgroups now returns early when /sys/fs/cgroup is already a cgroup2 mount (CGROUP2_SUPER_MAGIC via statfs), because the preparefs2 and LaunchDocker init steps run PrepareFs again after switchroot and would otherwise remount the v1 hierarchies on top of the cgroup2 filesystem, making them visible in the switched root again.