### PR TITLE
Fix autologin with Debian 13 based console

### DIFF
--- a/cmd/control/autologin.go
+++ b/cmd/control/autologin.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/burmilla/os/config"
 	"github.com/burmilla/os/pkg/log"
@@ -29,6 +31,13 @@ func AutologinMain() {
 }
 
 func autologinAction(c *cli.Context) error {
+	// login from util-linux (Debian 13 and later consoles) calls vhangup()
+	// on the tty, which sends SIGHUP to every other process holding the tty
+	// open — including this one. Ignore it so we keep waiting for the child
+	// instead of dying, which would make respawn restart agetty on top of
+	// the freshly started session.
+	signal.Ignore(syscall.SIGHUP)
+
 	cmd := exec.Command("/bin/stty", "sane")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout

--- a/images/02-console/Dockerfile
+++ b/images/02-console/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
                            net-tools bash-completion wget \
                            nano open-iscsi iputils-ping nvi \
                            apparmor nfs-common \
+                           lastlog2 libpam-lastlog2 \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
     && rm -rf /var/lib/apt/lists/* \
@@ -25,6 +26,11 @@ RUN apt-get update \
     && echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && echo '## allow password less for docker user' >> /etc/sudoers \
     && echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    # Debian 13 dropped shadow's lastlog; provide the command via lastlog2.
+    # Its database dir is normally created by systemd-tmpfiles which does
+    # not run here, so create it at build time.
+    && ln -s lastlog2 /usr/bin/lastlog \
+    && mkdir -p /var/lib/lastlog2 \
     && cat /etc/ssh/sshd_config > /etc/ssh/sshd_config.tpl \
     && cat /etc/ssh/sshd_config.append.tpl >> /etc/ssh/sshd_config.tpl \
     && rm -f /etc/ssh/sshd_config.append.tpl /etc/ssh/sshd_config \


### PR DESCRIPTION
Debian 13 replaced shadow's login with the util-linux implementation, which calls vhangup() on the tty before reopening it. That sends SIGHUP to the parent autologin process, killing it, after which respawn restarts agetty on top of the freshly started session and the automatic login never sticks.

Ignore SIGHUP in autologin so it survives the vhangup() and keeps waiting for the login child, restoring the pre-trixie behavior.


Claude-Session: https://claude.ai/code/session_01RQt7tNyr2dy7U8jAspaakN